### PR TITLE
DBM-2222: Fix selectedUserGroupId for users in a single group

### DIFF
--- a/packages/ipa-core/src/IpaDialogs/ProjectPickerModal.jsx
+++ b/packages/ipa-core/src/IpaDialogs/ProjectPickerModal.jsx
@@ -285,7 +285,8 @@ export default class ProjectPickerModal extends React.Component {
         await this.loadProject(project);
 
         sessionStorage.setItem(PROJECT_ID_KEY, project._id)
-        appContextProps.actions.setSelectedItems({selectedProject: currProject, selectedUserGroupId: this.state.selectedUserGroupId});
+        const selectedUserGroupId = this.state.projectUserGroups?.length === 1 ? this.state.projectUserGroups[0]._id : this.state.selectedUserGroupId;
+        appContextProps.actions.setSelectedItems({ selectedProject: currProject, selectedUserGroupId });
         window.location.hash = '/'; //Since we're outside the react router scope, we need to deal with the location object directly
 
         if (this.props.referenceAppConfig?.refApp) {


### PR DESCRIPTION
More details - https://invicara.atlassian.net/browse/DBM-2222

Essentially, when a user is member of only a single group, they don't see the dropdown to select a group. It is hidden when `projectUserGroups ` array contains less than 2 items. Therefore in that case `selectedUserGroupId` is never updated on the state.

The fix checks if the user is only a member of a single group and assigns the ID of that group.