### PR TITLE
DBM-2258: Resolved issue with action buttons not working

### DIFF
--- a/packages/ipa-core/src/IpaPageComponents/entities/EntityActionsPanel.jsx
+++ b/packages/ipa-core/src/IpaPageComponents/entities/EntityActionsPanel.jsx
@@ -9,7 +9,7 @@ import './EntityActionsPanel.scss';
 import '../../IpaStyles/DbmTooltip.scss'
 import ActionButton from "../../IpaControls/ActionButton";
 
-const EntityActionsPanel = ({actions, entity, type, context, getEntityActionComponent, iconRenderer}) => {
+const EntityActionsPanel = ({actions, entity, type, context, getEntityActionComponent, iconRenderer, showModal}) => {
   let icons = []
 
   const reduxStore = useStore();
@@ -65,7 +65,8 @@ const EntityActionsPanel = ({actions, entity, type, context, getEntityActionComp
       newEntity = await runPreEntityActionScript({action, entity: newEntity, type})
       // the factory create method can use the app context to display the component
       // e.g. context.ifefShowModal(modal)
-      factory.create({action, entity: newEntity, type, context, reduxStore})
+      // Issue with context being set to null which meant context.ifefShowModal was undefined. Passing through showModal from AppProvider as an alternative. 
+      factory.create({action, entity: newEntity, type, context, reduxStore, showModal})
     } else {
       // if there's no component execute the action directly
       let newEntity = action.showOnTable && Array.isArray(entity) ? [...entity] : Object.assign({}, entity)

--- a/packages/ipa-core/src/IpaPageComponents/entities/EntityCollectionModal.jsx
+++ b/packages/ipa-core/src/IpaPageComponents/entities/EntityCollectionModal.jsx
@@ -203,10 +203,12 @@ EntityCollectionModal.contextTypes = {
   ifefModalOpen: PropTypes.bool
 };
 
-export const EntityCollectionModalFactory = {
-  create: ({type, action, entity, context}) => {
-    let modal = <EntityCollectionModal action={action} entity={entity} type={type} />
-    context.ifefShowModal(modal);
-    return modal
-  }
+
+  export const EntityCollectionModalFactory = {
+    create: ({type, action, entity, context, reduxStore, showModal}) => {
+      let modal = <EntityCollectionModal action={action} entity={entity} type={type} />
+      // context.ifefShowModal(modal);
+      showModal(modal)
+      return modal
+    }
 }


### PR DESCRIPTION
Issue with the "Collections" button not working was being caused by the context object that was set to null. The Context object should contain the 'ifefShowModal' function which is called in the 'EntityCollectionModalFactory'. I provided this function with 'showModal(modal)' which is passed down from the AppProvider. The 'showModal(modal)' function has access to context and in turn calls 'ifefShowModal'.