### PR TITLE
Dbm 2263: Resolved entity data panel bugs

### DIFF
--- a/packages/ipa-core/src/IpaPageComponents/entities/EntityView.jsx
+++ b/packages/ipa-core/src/IpaPageComponents/entities/EntityView.jsx
@@ -32,7 +32,10 @@ const tableComponents = {
 
 class EntityView extends React.Component {
 
-    state = {displayDetail: false}
+    state = {
+        displayDetail: false,
+        selectedEntity: []
+    }
 
     openDetail = entity => {
         this.setState({displayDetail: true, selectedEntity: entity})
@@ -112,7 +115,7 @@ class EntityView extends React.Component {
                 pageContent = <EntityDetailPanel
                     context={this.context}
                     onSummary={this.openSummary}
-                    entity={this.props.selectedEntities[0]}
+                    entity={this.props.selectedEntities[0] || this.state.selectedEntity}
                     config={this.props.handler.config}
                     actions={actions}
                     availableDataGroups={this.props.availableDataGroups}

--- a/packages/ipa-core/src/IpaPageComponents/entities/EntityView.jsx
+++ b/packages/ipa-core/src/IpaPageComponents/entities/EntityView.jsx
@@ -35,7 +35,8 @@ class EntityView extends React.Component {
     state = {displayDetail: false}
 
     openDetail = entity => {
-        this.setState({displayDetail: true})
+        this.setState({displayDetail: true, selectedEntity: entity})
+        this.props.setAvailableDataGroups(entity)
         // this.props.entitiesSelected([entity]);
     }
 


### PR DESCRIPTION
Resolved the following two bugs:

1) DBM-2263: Manually setting the selectedEntity to local state in order to pass it along to the EntityDetailPanel component. We don't want to update the Redux selectedEntity state here as it would clear any entities that are selected in the 2nd panel.

2) DBM-2269: Manually calling the setAvailableDataGroups(entity) in order to pass through the selected entity data to load the correct data groups.