### PR TITLE
DBM-2276 fix: resolved modal not opening

### DIFF
--- a/packages/ipa-core/src/IpaPageComponents/entities/EntityCollectionModal.jsx
+++ b/packages/ipa-core/src/IpaPageComponents/entities/EntityCollectionModal.jsx
@@ -207,8 +207,11 @@ EntityCollectionModal.contextTypes = {
   export const EntityCollectionModalFactory = {
     create: ({type, action, entity, context, reduxStore, showModal}) => {
       let modal = <EntityCollectionModal action={action} entity={entity} type={type} />
-      // context.ifefShowModal(modal);
-      showModal(modal)
+      if(context.ifefShowModal) {
+        context.ifefShowModal(modal);
+      } else {
+        showModal(modal)
+      }
       return modal
     }
 }


### PR DESCRIPTION
Resolved the issue with the Entity Collection modal not opening on a button press. If the component is supplied with the context.ifefShowModal() property, it will use that to open the modal. Otherwise, we manually pass through the showModal() and use that.