### PR TITLE
DBM-2267 fix: stopping text overlay on mouse hover

### DIFF
--- a/packages/ipa-core/src/IpaUtils/TreeRendererHelper.js
+++ b/packages/ipa-core/src/IpaUtils/TreeRendererHelper.js
@@ -3,7 +3,7 @@ import '../IpaStyles/DbmTooltip.scss'
 
 //TODO Remove once fancy tree is everywhere replaced by ReactiveTree
 export const leafNodeRenderer = (entity) => 
-(<div title={entity["Entity Name"]}>{entity["Entity Name"]}
+(<div title={entity["Entity Name"]} style={{whiteSpace: "nowrap"}}>{entity["Entity Name"]}
     { entity["EntityWarningMessage"] && 
     <div className="tooltip-wrapper">
         <div className="dbm-tooltip">


### PR DESCRIPTION
Inside the EntitySelectionPanel, when a user hovers their mouse over an entity, the entire string is expanding and overlaying with any text that is below it. It is caused by a CSS property inside of TreeControl.scss  that was added in for use inside the System-Builder. 

The inline style showing in this commit is to overRide the above SCSS property to insure it works as expected in both the EntityView and System-Builder components. 