### PR TITLE
DBM-2283 fix: resets entity state on search panel selection

### DIFF
--- a/packages/ipa-core/src/IpaControls/EnhancedFetchControl.jsx
+++ b/packages/ipa-core/src/IpaControls/EnhancedFetchControl.jsx
@@ -55,6 +55,8 @@ class EnhancedFetchControl extends React.Component {
 
     //value is optional, it can be used to provide a value not yet available in the state.
     handleFetch = (selectorId, value, state) => {
+        // This will clear any entities that have been selected directly from the model
+        if(this.props.setViewerSelectedEntitiesBySearch) this.props.setViewerSelectedEntitiesBySearch([])
         //The disable props can prevent fetching. 
         // It is especially useful to prevent spontaneous fetching from TreeSearch after it reloads itself. 
         if(this.props.disable) return;


### PR DESCRIPTION
If a user does select an entity from the model and then decides to search for a different entity with the search panel, the 'viewerSelectedEntitiesBySearch' state in the Navigator is reset to ensure the correct panels either open or remain closed based on that specific user case.