### PR TITLE
DBM-2293: Allow custom header bar

### DIFF
--- a/packages/ipa-core/src/IpaLayouts/Layout.jsx
+++ b/packages/ipa-core/src/IpaLayouts/Layout.jsx
@@ -117,7 +117,7 @@ class Layout extends React.Component {
     getComponent(name) {
         let component
         try {
-            component = require('../../../../../app/ipaCore/components/' + name + '.jsx').default;
+            component = require('../../../../../app/ipaCore/' + name + '.jsx').default;
         } catch(e) {
             console.error(e)
             console.error("can't find page component: ", name)

--- a/packages/ipa-core/src/IpaLayouts/TitleBar.jsx
+++ b/packages/ipa-core/src/IpaLayouts/TitleBar.jsx
@@ -12,38 +12,61 @@ import './TitleBar.scss'
 import '../IpaIcons/icons.scss'
 
 export default class TitleBar extends React.Component {
-  render() {
-      let titleInfo = getTitleBarInfoFromProps('', this.props.contextProps);
+    render() {
+        let titleInfo = getTitleBarInfoFromProps('', this.props.contextProps);
 
-      const switchProj = (e) => {
-        e.preventDefault()
-        titleInfo.switchProject()
-      }
+        const switchProj = (e) => {
+            e.preventDefault()
+            titleInfo.switchProject()
+        }
 
-      const goToUserAccount = (e) => {
-          e.preventDefault()
-          window.open(getPlatformPath('USER_ACCOUNT'))
-      }
+        const goToUserAccount = (e) => {
+            e.preventDefault()
+            window.open(getPlatformPath('USER_ACCOUNT'))
+        }
 
-    return (
-        <HeaderBar customClasses="always-flex titlebar-header">
-            <Logo homepage="#/" appName={this.props.ipaConfig.appName} contextProps={this.props.contextProps}/>
-            <div id="active-session">
-                <div id="active-session-text">
-                    <div className={'session-dropdown'}>
-                        {titleInfo.projectName}
-                        <i className={'icofont-rounded-down'}/>
-                        <div className={'session-options'}>         
-                            <LinkedIcon customClass={'session-item'} clickHandler={switchProj} icon={'icofont-refresh icofont-2x'} linkText={'Switch Project'}/>
-                            <LinkedIcon customClass={'session-item'} clickHandler={this.props.parent.props.userLogout} iconClasses={'ipa-icon-svg'} iconImg={IconLogout} linkText={'Logout'}/>
-                            <LinkedIcon customClass={'session-item'} clickHandler={goToUserAccount} iconClasses={'ipa-icon-svg'} iconImg={IconUser} linkText={this.props.contextProps.user._firstname + " " + this.props.contextProps.user._lastname}/>
+        let customHeader
+        const userConfigSettings = this.props.contextProps?.userConfig?.settings
+        if (userConfigSettings.headerComponent) {
+            try {
+                customHeader = { component: require('../../../../../app/ipaCore/' + userConfigSettings.headerComponent + '.jsx').default }
+            } catch(error) {
+                console.error(`Header component not found at path ${userConfigSettings.headerComponent}. Using default header.`)
+            }
+        }
 
-                            <div className={'session-item'}>{version?.version}</div>
+        return (
+            <>
+                {customHeader?.component ? (
+                    <customHeader.component
+                        {...this.props.contextProps }
+                        titleInfo={titleInfo}
+                        switchProj={switchProj}
+                        goToUserAccount={goToUserAccount}
+                        userLogout={this.props.parent?.props?.userLogout}
+                        logoComponent={Logo}
+                    />
+                ) : (
+                    <HeaderBar customClasses="always-flex titlebar-header">
+                        <Logo homepage="#/" appName={this.props.ipaConfig.appName} contextProps={this.props.contextProps}/>
+                        <div id="active-session">
+                            <div id="active-session-text">
+                                <div className={'session-dropdown'}>
+                                    {titleInfo.projectName}
+                                    <i className={'icofont-rounded-down'}/>
+                                    <div className={'session-options'}>         
+                                        <LinkedIcon customClass={'session-item'} clickHandler={switchProj} icon={'icofont-refresh icofont-2x'} linkText={'Switch Project'}/>
+                                        <LinkedIcon customClass={'session-item'} clickHandler={this.props.parent.props.userLogout} iconClasses={'ipa-icon-svg'} iconImg={IconLogout} linkText={'Logout'}/>
+                                        <LinkedIcon customClass={'session-item'} clickHandler={goToUserAccount} iconClasses={'ipa-icon-svg'} iconImg={IconUser} linkText={this.props.contextProps.user._firstname + " " + this.props.contextProps.user._lastname}/>
+
+                                        <div className={'session-item'}>{version?.version}</div>
+                                    </div>
+                                </div>                    
+                            </div>
                         </div>
-                    </div>                    
-                </div>
-            </div>
-        </HeaderBar>
-    )
-  }
+                    </HeaderBar>
+                )}
+            </>
+        )
+   }
 }


### PR DESCRIPTION
https://invicara.atlassian.net/browse/DBM-2293

* Ability now to use a custom header bar component to replace the default one.
* Modified the previous change for custom sidebars (https://github.com/Invicara/Twinit-IPA-Core-React-Framework/pull/26) to allow using any folder within /ipaCore, instead of restricting it to /ipaCore/components. Giving the app developer slightly more freedom where to place the component.

To specify a custom header, in a userConfig file add the following setting which is a path to the JSX file relative to /ipaCore folder:

E.g.
```
{
    "settings: {
        "headerComponent:": "components/newHeaderBar/HeaderBar"
    }
}
```