### PR TITLE
DBM-1863 fix: adding no DT entity associated message

### DIFF
--- a/packages/ipa-core/src/redux/slices/entities-higher-order-reducer.js
+++ b/packages/ipa-core/src/redux/slices/entities-higher-order-reducer.js
@@ -203,6 +203,13 @@ export const entitiesSliceFactory = (identifier = '') => {
             if (!setIncludesBy(getAllCurrentEntities(getState()), filteredToSelect, (e) => (e?.modelData?.id || e?._id))) {
                 dispatch(setEntities({entities: filteredToSelect, shouldIsolate: false}))
             }
+            // If the selected entity has no DT properties associated with it
+            if(filteredToSelect.length < 1) {
+                const resObj = { 
+                    noEntityFound: 'No Digital Twin entity associated with the selected object'
+                }
+                return resObj
+            }
             dispatch(setSelectedEntities(filteredToSelect))
             dispatch(setSelecting(false))
         } catch (e) {


### PR DESCRIPTION
When a user selects a model element that has no relation to DT entities, we want to display a clear message detailing that as was the case with the old navigator.

![Screenshot 2024-12-10 at 16 18 10](https://github.com/user-attachments/assets/477bf4d7-73be-4c4e-8dbc-d7da7d7d3321)
