### PR TITLE
DBM-2368 Correct URL after accepting project invite.

### DIFF
--- a/packages/ipa-core/src/IpaDialogs/ProjectPickerModal.jsx
+++ b/packages/ipa-core/src/IpaDialogs/ProjectPickerModal.jsx
@@ -292,6 +292,10 @@ export default class ProjectPickerModal extends React.Component {
         appContextProps.actions.setSelectedItems({ selectedProject: currProject, selectedUserGroupId });
         window.location.hash = '/'; //Since we're outside the react router scope, we need to deal with the location object directly
 
+        // After a user accepts an invite, we make sure to remove the 'inviteId' from the URL
+        if(window.location.href.includes('inviteId')) {
+          window.location.href = `${window.location.origin}/`
+        }
         if (this.props.referenceAppConfig?.refApp) {
           window.history.replaceState({}, document.title, window.location.pathname + window.location.hash);
         }


### PR DESCRIPTION
After a user accepts a project invite via an email, a query for 'inviteId' is left in the URL. This is causing an issue when the user then opens up a project as the URL will read 'digitaltwin/<inviteId>/<page handler>/'. There is a small function that checks for the presence of an 'inviteId' when the user selects 'Load Project' from the ProjectPickerModal. If so, then we remove it from the URL.