### PR TITLE
DBM-2380: processCache for ScriptCache

### DIFF
--- a/packages/ipa-core/docs/userconfigs/pagehandlers/scriptCache.md
+++ b/packages/ipa-core/docs/userconfigs/pagehandlers/scriptCache.md
@@ -22,5 +22,7 @@ Please find a list of all the functions provided by the `ScriptCache` below
 
 
 ### `clearCache`
-
 `ScriptCache.clearCache()` allows a user to clear the Cache.
+
+### `processCache`
+`ScriptCache.processCache(function)` allows a user to process the Cache using a function argument. The passed in function has access to cachedPromises.

--- a/packages/ipa-core/src/IpaUtils/script-cache.js
+++ b/packages/ipa-core/src/IpaUtils/script-cache.js
@@ -51,9 +51,13 @@ const runScript = (...args) => {
 }
 
 const clearCache = () => {
-  cachedPromises = {}
+    cachedPromises = {}
 }
 
-const ScriptCache = { runScript, clearCache }
+const processCache = (fn) => {
+    return fn(cachedPromises)
+}
+
+const ScriptCache = { runScript, clearCache, processCache }
 
 export default ScriptCache;


### PR DESCRIPTION
https://invicara.atlassian.net/browse/DBM-2380

Sometimes we want to clear a specific cache for a `ScriptCache.runScript` from the app, without clearing the entire cache (`ScriptCache.clearCache`).

`ScriptCache.processCache` allows passing in a function which will have access to `cachedPromises` so that it can be manipulated.

Example usage in app:
```
import { ScriptCache } from "@invicara/ipa-core/modules/IpaUtils";

const MyComponent = () => {
    ScriptCache.processCache((cachedPromises) => {
        ...
        if cachedPromises contains specific cache, delete it or change its expiry etc
        ...
    })
}
```