### PR TITLE
DBM-2379: Removing function blocker

### DIFF
--- a/packages/ipa-core/src/IpaControls/EnhancedScriptedLinkedSelects.jsx
+++ b/packages/ipa-core/src/IpaControls/EnhancedScriptedLinkedSelects.jsx
@@ -52,10 +52,6 @@ export const ScriptedLinkedSelects = ({
   };
 
   const updateFetchOptions = async () => {
-    // If called from File Table, using the LinkedSelectValues provided to avoid repeated script calls.
-    if(LinkedSelectValues) {
-      setSelects(LinkedSelectValues)
-    } else {
       let newSelects = await fetchOptions(selects);
       if (currentValue) {
         let selectKeys = Object.keys(selects);
@@ -72,7 +68,6 @@ export const ScriptedLinkedSelects = ({
           } else break;
         }
       }
-    }
   };
 
   const fetchOptions = async (
@@ -80,8 +75,7 @@ export const ScriptedLinkedSelects = ({
     currentSelect,
     previousSelectsValues,
   ) => {
-    const nextSelect =
-      _.values(selects)[currentSelect ? currentSelect.index + 1 : 0];
+    const nextSelect = _.values(selects)[currentSelect ? currentSelect.index + 1 : 0];
     let newSelects;
 
     if (nextSelect) {


### PR DESCRIPTION
Unnecessary if statement was causing the function to not run the updateFetchOptions function. 

This caused issues during the File upload when a user would try to assign a dtCategory and dtType to a File. On the first select of a dtCategory, the selection would remain blank with a script error appearing in the console. It would not save the selected values of these two dropdowns to the fileObj.properties as expected.