### PR TITLE
DBM-2385 Resolved undefined variable

### DIFF
--- a/packages/ipa-core/src/IpaControls/TreeSearch.jsx
+++ b/packages/ipa-core/src/IpaControls/TreeSearch.jsx
@@ -128,8 +128,9 @@ export const TreeSearch = ({ currentValue = {}, currentState, onFetch, treeLevel
         treeLevelsLatest.current = treeLevels;
         try {
             refreshTree().then((nodeIndex) => {
+                console.log('Adam TreeSearch handler', handler)
                 // This will auto select all entities on the page render.
-                if(handler.config.selectAllOnRender) {
+                if(handler?.config?.selectAllOnRender) {
                     const newNodeIndex = toggleSelectedStatus(nodeIndex)
                     handleNodeIndexChange(newNodeIndex)
                 }


### PR DESCRIPTION
TreeSearch was not loading when rendering it from the Navigator. This was due to a missing prop that is only provided to the TreeSearch when rendered from the EntityView.