### PR TITLE
fix(security): override minimatch, flatted, lodash.template to patched versions (DBM)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5087,10 +5087,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
@@ -7983,10 +7984,12 @@
       "dev": true
     },
     "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.18.1.tgz",
+      "integrity": "sha512-5urZrLnV/VD6zHK5KsVtZgt7H19v51mIzoS0aBNH8yp3I8tbswrEjOABOPY8m8uB7NuibubLrMX+Y0PXsU9X+w==",
+      "deprecated": "This package is deprecated. Use https://socket.dev/npm/package/eta instead.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -8622,10 +8625,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },

--- a/package.json
+++ b/package.json
@@ -24,5 +24,10 @@
       "npx prettier --write",
       "npx eslint --fix"
     ]
+  },
+  "overrides": {
+    "minimatch": "^3.1.3",
+    "flatted": "^3.4.2",
+    "lodash.template": "^4.18.1"
   }
 }


### PR DESCRIPTION
## Summary

Three high-severity Dependabot alerts (`minimatch`, `flatted`, `lodash.template`) had **no Dependabot PR** because no ancestor in the dependency tree offers a compatible upgrade path. All three are **dev/build-tooling transitive deps** (pulled by eslint, flat-cache, and `@lerna/conventional-commits`) — none ship in the published `@invicara/ipa-core` runtime bundle.

Each is a **safe within-major bump** that satisfies every existing parent range, so they are pinned via npm `overrides`:

| package | was | now | advisory |
|---|---|---|---|
| minimatch | 3.1.2 | ^3.1.3 | ReDoS |
| flatted | 3.3.1 | ^3.4.2 | prototype pollution |
| lodash.template | 4.5.0 | ^4.18.1 | code injection |

## Verification (local)
- ✅ `npm install` — clean, no `ERESOLVE`
- ✅ `npm audit` — all three advisories cleared
- ✅ `npm run bootstrap && npm run build` — succeeds (rollup build of `@invicara/ipa-core` OK)

## Not included on purpose
`tar` and `braces` are **not** overridden — forcing them would violate the lerna-3 chain's `^4.x` / `^2.x` parent ranges and change APIs. Those two are addressed by the separate **lerna 3→9 upgrade** (Dependabot PR #138), which also removes them (and `ip` / `lodash.set`) from the tree.

Filed under DBM alongside the security-alert cleanup. No linked Jira ticket auto-created for this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)