### PR TITLE
fix: use AuthService for post-logout redirect

### DIFF
--- a/packages/ipa-core/src/AppProvider.jsx
+++ b/packages/ipa-core/src/AppProvider.jsx
@@ -127,14 +127,14 @@ export class AppProvider extends React.Component {
   async userLogout() {
     try {
       await IafSession.logout();
-    } catch (e) {console.error("An unexpected error happened while logging out.")}
+    } finally {
+      this.sisenseLogout();
 
-    this.sisenseLogout()
-
-    // delete cached config
-    delete sessionStorage.ipadt_configData;
-    delete localStorage.ipadt_selectedItems;
-    window.location = this.authUrl;
+      // delete cached config
+      delete sessionStorage.ipadt_configData;
+      delete localStorage.ipadt_selectedItems;
+      this.props.authService.authorize();
+    }
   }
 
   closeBottomPanel() {


### PR DESCRIPTION
## Summary

Fixes a logout failure in apps that use `ipa-core` with `@dtplatform/platform-api` 5.x (e.g. Asset Intelligence App).

After logout, `AppProvider.userLogout()` previously redirected via `IafSession.getAuthUrl()`, which in platform-api 5.x produces a v2 OAuth authorize URL with `response_type=code` but no PKCE parameters. That request returns **400 Bad Request**.

This change redirects through `authService.authorize()` instead, matching the login flow and respecting `endPointConfig.authType` (implicit or PKCE).

## Changes

- **`packages/ipa-core/src/AppProvider.jsx`**
  - Replace `window.location = this.authUrl` with `this.props.authService.authorize()` after logout cleanup
  - Use `try/finally` instead of `try/catch` so Sisense logout, session/localStorage cleanup, and the login redirect always run

## Why this approach

| Before | After |
|---|---|
| Logout used `IafSession.getAuthUrl()` | Logout uses `AuthService.authorize()` |
| Broken v2 code grant URL (no PKCE) with platform-api 5.x | Same auth path as login |
| Decoupled from `authType` config | Respects `endPointConfig.authType` |